### PR TITLE
Remove datepicker() hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ Call the datetimepicker via javascript:
     $('.datetimepicker').fdatetimepicker()
 
 
-Call the datepicker via javascript:
-
-    $('.datepicker').fdatepicker()
-
 ## Usage
 
 See the excellent demo provided by plugin's author - [here](http://foundation-datepicker.peterbeno.com/example.html).


### PR DESCRIPTION
Hey, thx for the GEM. The date*time*-Picker works out of the box. The README says that `datepicker()` should also work, but I don't see any code in the JS that would make that possible. So I suggest to remove that line to avoid confusion.